### PR TITLE
[docker] Add NVD Nist CVE collector and NMAP and Nuclei injectors by default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,13 @@ COLLECTOR_OPENBAS_ID=63544750-19a1-435f-ada4-b44e39cf3cdb
 
 # Collector Atomic Red Team Configuration
 COLLECTOR_ATOMIC_RED_TEAM_ID=c34e3f19-e0b9-45cb-83e0-3b329e4c53d3
+
+# Collector CVE by NVD NIST Configuration
+COLLECTOR_NVD_NIST_CVE_ID=2caac5d2-31c7-4804-adfd-f92d1b2e7eda
+COLLECTOR_NVD_NIST_CVE_API_KEY= #Optionnal but recommended
+
+#Injector NMAP
+INJECTOR_NMAP_ID=76f8f4d6-9f6f-4e61-befc-48f735876a4a
+
+#Injector Nuclei
+INJECTOR_NUCLEI_ID=e1bad898-9804-427d-99e4-dc32c5f2898d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,43 @@ services:
       openbas:
         condition: service_healthy
     restart: always
+  collector-nvd-nist-cve:
+    image: openbas/collector-nvd-nist-cve:prerelease
+    environment:
+      - OPENBAS_URL=http://openbas:8080
+      - OPENBAS_TOKEN=${OPENBAS_ADMIN_TOKEN}
+      - COLLECTOR_ID=${COLLECTOR_NVD_NIST_CVE_ID} # Valid UUIDv4
+      - NVD_NIST_CVE_API_KEY=${COLLECTOR_NVD_NIST_CVE_API_KEY}
+      - "COLLECTOR_NAME=Cve by NVD NIST"
+      - COLLECTOR_LOG_LEVEL=info
+    depends_on:
+      openbas:
+        condition: service_healthy
+    restart: always
+  injector-nmap:
+    image: openbas/injector-nmap:1.18.18
+    environment:
+      - OPENBAS_URL=http://openbas:8080
+      - OPENBAS_TOKEN=${OPENBAS_ADMIN_TOKEN}
+      - INJECTOR_ID=${INJECTOR_NMAP_ID} # Valid UUIDv4
+      - "INJECTOR_NAME=Nmap"
+      - INJECTOR_LOG_LEVEL=info
+    depends_on:
+      openbas:
+        condition: service_healthy
+    restart: always
+  injector-nuclei:
+    image: openbas/injector-nuclei:1.18.18
+    environment:
+      - OPENBAS_URL=http://openbas:8080
+      - OPENBAS_TOKEN=${OPENBAS_ADMIN_TOKEN}
+      - INJECTOR_ID=${INJECTOR_NUCLEI_ID} # Valid UUIDv4
+      - "INJECTOR_NAME=Nuclei"
+      - INJECTOR_LOG_LEVEL=info
+    depends_on:
+      openbas:
+        condition: service_healthy
+    restart: always
 volumes:
   pgsqldata:
   s3data:


### PR DESCRIPTION
**Context**
For the StarterPack process, we need to implement by default one new collector (Cve by NVD NIST) and two new injectors (NMAP and Nuclei).

**Proposed changes**

- Add collector NVD Nist CVE
- Add injector NMAP
- Add injector Nuclei

Related issues
Closes https://github.com/OpenAEV-Platform/openaev/issues/3527

**Warning**
Since NVD Nist CVE doesn't have a stable version yet (12/09/2025), it's important to wait for this stable version before merging.
The prerelease version is set in the meantime.